### PR TITLE
Update Jakarta EE dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-web-api</artifactId>
-            <version>8.0</version>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-web-api</artifactId>
+            <version>8.0.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- disable jaeger to pass security scan -->


### PR DESCRIPTION
Replace Java EE dependency with Jakarta EE dependency.
The release note for MicroProfile 4.0 states that the Java EE 8 dependencies have been replaced by the Jakarta EE 8 counterparts. This sample should reflect that.